### PR TITLE
Mask Errors in Client Streaming

### DIFF
--- a/core/src/main/scala/org/http4s/grpc/ClientGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/ClientGrpc.scala
@@ -75,7 +75,7 @@ object ClientGrpc {
     val req = Request(Method.POST, baseUri / serviceName / methodName, HttpVersion.`HTTP/2`)
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
-      .withBodyStream(codecs.Messages.encode(encode)(message))
+      .withBodyStream(codecs.Messages.encode(encode)(message).mask)
       .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
     client.run(req).use( resp =>
@@ -100,7 +100,7 @@ object ClientGrpc {
     val req = Request(Method.POST, baseUri / serviceName / methodName, HttpVersion.`HTTP/2`)
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
-      .withBodyStream(codecs.Messages.encode(encode)(message))
+      .withBodyStream(codecs.Messages.encode(encode)(message).mask)
       .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
 


### PR DESCRIPTION
Same as server for client. Perhaps should surface in result stream eventually. For now this ensures we don't hang.