### PR TITLE
Add `TypeMapper` for `ByteVector`

### DIFF
--- a/core/src/main/scala/org/http4s/grpc/codecs/ScalaPb.scala
+++ b/core/src/main/scala/org/http4s/grpc/codecs/ScalaPb.scala
@@ -14,7 +14,7 @@ object ScalaPb {
 
   private def decoderForGenerated[A <: GeneratedMessage](companion: GeneratedMessageCompanion[A]): Decoder[A] = {
     Decoder[A]((b: BitVector) =>
-      Attempt.fromTry(companion.validate(b.bytes.toArray))
+      Attempt.fromTry(companion.validate(b.bytes.toArrayUnsafe))
         .map(a => DecodeResult(a, BitVector.empty))
     )
   }

--- a/core/src/main/scala/org/http4s/grpc/codecs/ScalaPb.scala
+++ b/core/src/main/scala/org/http4s/grpc/codecs/ScalaPb.scala
@@ -1,7 +1,8 @@
 package org.http4s.grpc.codecs
 
+import com.google.protobuf.ByteString
 import scodec.{Encoder, Decoder, Attempt, Codec, DecodeResult}
-import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion, TypeMapper}
 import scodec.bits.{ByteVector, BitVector}
 
 // Should this be its own subproject?
@@ -21,4 +22,10 @@ object ScalaPb {
   def codecForGenerated[A <: GeneratedMessage](companion: GeneratedMessageCompanion[A]): Codec[A] = {
     Codec[A](encoderForGenerated(companion), decoderForGenerated(companion))
   }
+
+  implicit def byteVectorTypeMapper: TypeMapper[ByteString, ByteVector] =
+    new TypeMapper[ByteString, ByteVector] {
+      def toCustom(bs: ByteString) = ByteVector.view(bs.toByteArray)
+      def toBase(bv: ByteVector) = ByteString.copyFrom(bv.toArrayUnsafe)
+    }
 }


### PR DESCRIPTION
This allows users to customize generated code to use `ByteVector` for the bytes type.