### PR TITLE
Allow other clients than http4s-ember

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,9 +18,9 @@ ThisBuild / crossScalaVersions := Seq(Scala213, "3.3.1")
 ThisBuild / scalaVersion := Scala213
 
 val catsV = "2.10.0"
-val catsEffectV = "3.5.2"
-val fs2V = "3.9.2"
-val http4sV = "0.23.23"
+val catsEffectV = "3.5.3"
+val fs2V = "3.9.4"
+val http4sV = "0.23.25"
 val munitCatsEffectV = "2.0.0-M3"
 import scalapb.compiler.Version.scalapbVersion
 
@@ -43,8 +43,8 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "co.fs2"                      %%% "fs2-scodec"                 % fs2V,
 
       "org.http4s"                  %%% "http4s-dsl"                 % http4sV,
-      "org.http4s"                  %%% "http4s-ember-server"        % http4sV,
-      "org.http4s"                  %%% "http4s-ember-client"        % http4sV,
+      "org.http4s"                  %%% "http4s-server"              % http4sV,
+      "org.http4s"                  %%% "http4s-client"              % http4sV,
 
       "org.typelevel"               %%% "munit-cats-effect"        % munitCatsEffectV         % Test,
 

--- a/core/src/main/scala/org/http4s/grpc/ClientGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/ClientGrpc.scala
@@ -7,7 +7,6 @@ import org.http4s._
 import org.http4s.client.Client
 import scodec.{Encoder, Decoder}
 import fs2._
-import org.http4s.ember.core.h2.H2Keys
 import org.http4s.grpc.codecs.NamedHeaders
 
 object ClientGrpc {
@@ -25,7 +24,6 @@ object ClientGrpc {
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
       .withBodyStream(codecs.Messages.encodeSingle(encode)(message))
-      .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
     client.run(req).use( resp => 
       handleFailure(resp.headers) >>
@@ -51,7 +49,6 @@ object ClientGrpc {
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
       .withBodyStream(codecs.Messages.encodeSingle(encode)(message))
-      .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
     Stream.resource(client.run(req)).flatMap( resp =>
       Stream.eval(handleFailure(resp.headers)).drain ++
@@ -76,7 +73,6 @@ object ClientGrpc {
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
       .withBodyStream(codecs.Messages.encode(encode)(message).mask)
-      .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
     client.run(req).use( resp =>
       handleFailure(resp.headers) >>
@@ -101,7 +97,6 @@ object ClientGrpc {
       .putHeaders(SharedGrpc.TE, SharedGrpc.GrpcEncoding, SharedGrpc.GrpcAcceptEncoding, SharedGrpc.ContentType)
       .putHeaders(ctx.headers.map(Header.ToRaw.rawToRaw):_*)
       .withBodyStream(codecs.Messages.encode(encode)(message).mask)
-      .withAttribute(H2Keys.Http2PriorKnowledge, ())
 
 
     Stream.resource(client.run(req)).flatMap( resp =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9


### PR DESCRIPTION
This also works with http4-netty, and we should not limit this only to ember.

This removes the dependencies to ember server and client in favour of https-client and http4s-server.

Upgrades the fs2, cats-effect and http4s dependencies to the latest releases
Upgrades sbt